### PR TITLE
Prevent duplicated names

### DIFF
--- a/tinytoc.php
+++ b/tinytoc.php
@@ -204,6 +204,7 @@ class tinyTOC {
     $items = array();
     $min_depth = 6;
     $parent = array();
+    $used = array();
     for ( $i=0; $i<$tags->length; ++$i ) {
       $text = $tags->item($i)->nodeValue;
       $id = $tags->item($i)->getAttribute('id');
@@ -222,6 +223,15 @@ class tinyTOC {
             $name = $id.'-'.$slug; 
           break;
         }
+        // Prevent the same names
+        $old_name = $name;
+        if ( in_array( $name, $used ) ) {
+          $occurences = array_count_values($used);
+          $next_number = ( count( $occurences[$name] ) + 1 );
+          $name = $name .'-'. $next_number;
+        }
+        $used[] = $old_name;
+
         $tags->item($i)->setAttribute('id',$name);
       }
       $depth = $tags->item($i)->nodeName[1];

--- a/tinytoc.php
+++ b/tinytoc.php
@@ -227,7 +227,7 @@ class tinyTOC {
         $old_name = $name;
         if ( in_array( $name, $used ) ) {
           $occurences = array_count_values($used);
-          $next_number = ( count( $occurences[$name] ) + 1 );
+          $next_number = ( $occurences[$name] + 1 );
           $name = $name .'-'. $next_number;
         }
         $used[] = $old_name;


### PR DESCRIPTION
Prevent duplicated id/href names by adding "-2" etc.

So if you have third headers "Something" (sometimes it's as h3/h4 for nested content), the names will be like:
`something`
`something-2`
`something-3`