### PR TITLE
Fix for PHP < 5.3.6

### DIFF
--- a/tinytoc.php
+++ b/tinytoc.php
@@ -194,6 +194,7 @@ class tinyTOC {
     return $parent;
   }
   private static function parse(&$content) {
+    $content = mb_convert_encoding($content, 'HTML-ENTITIES', get_bloginfo('charset'));
     $content = '<html><head><meta charset="'.get_bloginfo('charset').'"></head><body>'.($content).'</body></html>';
     $dom = new DOMDocument();
     libxml_use_internal_errors(true);
@@ -238,7 +239,7 @@ class tinyTOC {
       $items[] = $item;
     }
     $text = $xpath->query('/html/body');
-    $text = $dom->saveHTML($text->item(0));
+    $text = ( version_compare(PHP_VERSION, '5.3.6', '>=') ? $dom->saveHTML($text->item(0)) : $dom->saveXML($text->item(0)) );
     $content = $text;
     return $items;
   }


### PR DESCRIPTION
Fix (not pretty) for PHP < 5.3.6 (as saveHTML's node was added in 5.3.6).

So in PHP < 5.3.6 using plugin resulting in notice/error and doesn't outputs anything.
Fix is returning in XML (so that's why using additional charset definition), however it may convert some self-closing tags.
I don't found better solution.

The best way is in my opinion don't use DOM at all or maybe try with library like [PHP Simple HTML DOM Parser](http://simplehtmldom.sourceforge.net/).