### PR TITLE
Fix for nested TOC if no 3 top-level headers.

### DIFF
--- a/tinytoc.php
+++ b/tinytoc.php
@@ -176,7 +176,7 @@ class tinyTOC {
         $parent = $items[$previous]->db_id;
       }
     } while (!$parent && sizeof($items)-$i > 0);
-    if (sizeof($items)-$i == 0) { return 0; }
+    if (!$parent && sizeof($items)-$i == 0) { return 0; }
     $a = 0;
     while ($item->depth - $items[$previous]->depth > 1) {
       ++$a;


### PR DESCRIPTION
Unexpected behaviour in TOC, as before fix:

```
Header 2
Header 3
Header 3
Header 2
-> Header 3
-> Header 3
```

Expected behaviour in TOC, as from fix:
```
Header 2
-> Header 3
-> Header 3
Header 2
-> Header 3
-> Header 3
```