### PR TITLE
`tinytoc_content` filter instead `tinytoc_widget_content`

### DIFF
--- a/includes/widget.php
+++ b/includes/widget.php
@@ -12,9 +12,8 @@ class TinyTOC_Widget extends WP_Widget {
 	function widget( $args, $instance ) {
 		// only show widget on single pages
 		if( !is_singular() ) return;
-		$content = apply_filters('tinytoc_widget_content', $GLOBALS['posts'][0]->post_content );
 		$min = $instance['min'];
-		$toc = tinyTOC::create($content, $min);
+		$toc = tinyTOC::create($GLOBALS['posts'][0]->post_content, $min);
 		if ( !$toc ) {
 			return;
 		}

--- a/tinytoc.php
+++ b/tinytoc.php
@@ -151,6 +151,7 @@ class tinyTOC {
     return $content;
   }
   public static function create(&$content, $min) {
+    $content = apply_filters( 'tinytoc_content', $content );
     $items = self::parse($content);
     $output = '';
     if (sizeof($items)>=$min) {


### PR DESCRIPTION
Related: #6 

I found `tinytoc_content` useful when using TOC on another site - not in widget.
This way is better, because this will filter widget, shortcode, `get_toc()`, `the_toc()` and automatically output.
